### PR TITLE
Fixed syntax of create view in adapters.sql

### DIFF
--- a/dbt/include/azuresynapse/macros/adapters.sql
+++ b/dbt/include/azuresynapse/macros/adapters.sql
@@ -78,9 +78,8 @@
 {% endmacro %}
 
 {% macro azuresynapse__create_view_as(relation, sql, auto_begin=False) -%}
-  create view {{ relation.schema }}.{{ relation.identifier }} as (
+  create view {{ relation.schema }}.{{ relation.identifier }} as 
     {{ sql }}
-  );
 {% endmacro %}
 
 {% macro azuresynapse__rename_relation(from_relation, to_relation) -%}


### PR DESCRIPTION
Hi ,

DDL for creating view had extra parenthesis which was resulting in ddl failure while creating source views
Removed the extra parenthesis.

Tested with dbt `version 0.18` and Synapse `version  10.0.15218.0` 