### PR TITLE
Added conn vars for trustservercertificate and encrypt

### DIFF
--- a/dbt/adapters/azuresynapse/connections.py
+++ b/dbt/adapters/azuresynapse/connections.py
@@ -29,9 +29,11 @@ class AzureSynapseCredentials(Credentials):
     server: str
     database: str
     schema: str
+    authentication: AuthenticationType
     username: Optional[str]
     password: Optional[str]
-    authentication: AuthenticationType
+    trustServerCertificate: Optional[bool] = False
+    encrypt: Optional[bool] = True
 
     _ALIASES = {
         "UID": "username",
@@ -49,6 +51,8 @@ class AzureSynapseCredentials(Credentials):
         parts.append(f"DRIVER={{{self.driver}}}")
         parts.append(f"SERVER={self.server}")
         parts.append(f"Database={self.database}")
+        parts.append("TrustServerCertificate={}".format('yes' if self.trustServerCertificate else 'no'))
+        parts.append("Encrypt={}".format('yes' if self.encrypt else 'no'))
 
         if self.authentication == AuthenticationType.TrustedConnection:
             parts.append("trusted_connection=yes")


### PR DESCRIPTION
@ebarajas Need to have this in order to support tunneling for customers who want to use Azure Synapse using an SSH bastion.